### PR TITLE
Content-Security-Policy toegvoegd aan heel de website

### DIFF
--- a/wpr-gr-i/public/index.html
+++ b/wpr-gr-i/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self';">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
Heb letterlijk maar 1 lijn code toegevoegd aan de index.html file. "This part sets the allowed sources for scripts to be from the same origin as the document ('self'). It restricts the execution of scripts to those originating from the same domain, enhancing security by preventing the execution of scripts from external sources."